### PR TITLE
fix: Ensure vertical alignment of catSelection / aside grid area remains flush top

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -31,7 +31,15 @@
   grid-area: aside;
   grid-row: 2 / span 2;
   justify-content: center;
+  /* The .catSelection itself is the `aside` in the .wrapper grid above. If the
+   * value below is `center`, this will shift up and down as the `content` grid
+   * section adjusts in height, e.g. the photo for Bethany is taller, ergo this
+   * section will shift down.
   align-content: center;
+   *
+   * a value of `start` will keep this flush top.
+   */
+  align-content: start;
 }
 .catSelection h1, ul {
   padding: 20px;


### PR DESCRIPTION
The "Choose Your Cat:" section would shift up/down based on the height of the content/photo. I figured it should remain vertically aligned to the top.

Before / after screenshot:
![image](https://user-images.githubusercontent.com/2334143/47612720-9a907080-da56-11e8-8d73-6be838674afc.png)
